### PR TITLE
fix: add navigation param validation and lesson bounds checking

### DIFF
--- a/app/video/[courseId]/[lessonId].tsx
+++ b/app/video/[courseId]/[lessonId].tsx
@@ -5,6 +5,7 @@ import {
 	ScrollView,
 	StatusBar,
 	StyleSheet,
+	Text,
 	TouchableOpacity,
 	View,
 } from "react-native";
@@ -42,6 +43,11 @@ export default function VideoPlayerScreen() {
 	const progressIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
 	const { isWeb } = usePlatform();
+
+	// Validate route parameters
+	const hasValidParams = Boolean(courseId?.trim() && lessonId?.trim());
+	const isLessonNotFound = lessonData.title === "Lesson Not Found";
+
 	useEffect(() => {
 		if (courseId) {
 			updateLastAccessed(courseId);
@@ -140,6 +146,33 @@ export default function VideoPlayerScreen() {
 
 	const headerBackground = isWeb ? colors.background.tertiary : "#000";
 
+	if (!hasValidParams || isLessonNotFound) {
+		return (
+			<View style={styles.errorContainer}>
+				<StatusBar barStyle="light-content" />
+				<Text style={styles.errorTitle}>
+					{!hasValidParams
+						? t("common.error")
+						: t("video.lessonNotFound")}
+				</Text>
+				<Text style={styles.errorMessage}>
+					{!hasValidParams
+						? t("video.invalidParams")
+						: t("video.lessonNotFoundMessage")}
+				</Text>
+				<TouchableOpacity
+					style={styles.errorBackButton}
+					onPress={() => router.back()}
+					accessibilityLabel={t("common.back")}
+					accessibilityRole="button"
+				>
+					<ArrowLeft size={20} color={colors.text.inverse} />
+					<Text style={styles.errorBackText}>{t("common.goBack")}</Text>
+				</TouchableOpacity>
+			</View>
+		);
+	}
+
 	return (
 		<View style={[styles.container, { backgroundColor: headerBackground }]}>
 			<StatusBar barStyle="light-content" />
@@ -233,5 +266,39 @@ const styles = StyleSheet.create({
 	infoScroll: {
 		flex: 1,
 		backgroundColor: colors.background.secondary,
+	},
+	errorContainer: {
+		flex: 1,
+		justifyContent: "center",
+		alignItems: "center",
+		backgroundColor: colors.background.primary,
+		padding: 32,
+	},
+	errorTitle: {
+		fontSize: 20,
+		fontWeight: "700",
+		color: colors.text.primary,
+		marginBottom: 8,
+	},
+	errorMessage: {
+		fontSize: 15,
+		color: colors.text.secondary,
+		textAlign: "center",
+		marginBottom: 24,
+		lineHeight: 22,
+	},
+	errorBackButton: {
+		flexDirection: "row",
+		alignItems: "center",
+		backgroundColor: colors.primary.main,
+		paddingHorizontal: 20,
+		paddingVertical: 12,
+		borderRadius: 12,
+		gap: 8,
+	},
+	errorBackText: {
+		fontSize: 15,
+		fontWeight: "600",
+		color: colors.text.inverse,
 	},
 });

--- a/locales/am/translation.json
+++ b/locales/am/translation.json
@@ -24,7 +24,8 @@
 		"refresh": "አድስ",
 		"viewAll": "ሁሉንም ተመልከት",
 		"seeMore": "ተጨማሪ ይመልከቱ",
-		"seeLess": "ያነሰ ይመልከቱ"
+		"seeLess": "ያነሰ ይመልከቱ",
+		"goBack": "ተመለስ"
 	},
 	"navigation": {
 		"home": "መነሻ",
@@ -174,7 +175,10 @@
 		"upNext": "ቀጥሎ",
 		"autoplayIn": "በራስ-ሰር በ{{seconds}} ሰከንድ ውስጥ ይጫወታል",
 		"completed": "ትምህርት ተጠናቅቋል!",
-		"markComplete": "እንደተጠናቀቀ ምልክት አድርግ"
+		"markComplete": "እንደተጠናቀቀ ምልክት አድርግ",
+		"lessonNotFound": "ትምህርት አልተገኘም",
+		"lessonNotFoundMessage": "ይህ ትምህርት የለም ወይም ተወግዷል።",
+		"invalidParams": "የትምህርት ማገናኛው ልክ አይደለም። እባክዎ ተመልሰው ይሞክሩ።"
 	},
 	"voice": {
 		"listening": "በማዳመጥ ላይ...",

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -24,7 +24,8 @@
 		"refresh": "Refresh",
 		"viewAll": "View All",
 		"seeMore": "See More",
-		"seeLess": "See Less"
+		"seeLess": "See Less",
+		"goBack": "Go Back"
 	},
 	"navigation": {
 		"home": "Home",
@@ -174,7 +175,10 @@
 		"upNext": "Up Next",
 		"autoplayIn": "Autoplay in {{seconds}}s",
 		"completed": "Lesson Completed!",
-		"markComplete": "Mark as Complete"
+		"markComplete": "Mark as Complete",
+		"lessonNotFound": "Lesson Not Found",
+		"lessonNotFoundMessage": "This lesson doesn't exist or may have been removed.",
+		"invalidParams": "The lesson link is invalid. Please go back and try again."
 	},
 	"voice": {
 		"listening": "Listening...",

--- a/locales/sw/translation.json
+++ b/locales/sw/translation.json
@@ -24,7 +24,8 @@
 		"refresh": "Onyesha Upya",
 		"viewAll": "Tazama Zote",
 		"seeMore": "Angalia Zaidi",
-		"seeLess": "Angalia Kidogo"
+		"seeLess": "Angalia Kidogo",
+		"goBack": "Rudi Nyuma"
 	},
 	"navigation": {
 		"home": "Nyumbani",
@@ -174,7 +175,10 @@
 		"upNext": "Inayofuata",
 		"autoplayIn": "Itacheza otomatiki baada ya sekunde {{seconds}}",
 		"completed": "Somo Limekamilika!",
-		"markComplete": "Weka kama Iliyokamilika"
+		"markComplete": "Weka kama Iliyokamilika",
+		"lessonNotFound": "Somo Halipatikani",
+		"lessonNotFoundMessage": "Somo hili halipo au linaweza kuwa limeondolewa.",
+		"invalidParams": "Kiungo cha somo si sahihi. Tafadhali rudi nyuma ujaribu tena."
 	},
 	"voice": {
 		"listening": "Inasikiliza...",

--- a/src/components/video/LessonInfoPanel.tsx
+++ b/src/components/video/LessonInfoPanel.tsx
@@ -96,10 +96,14 @@ export function LessonInfoPanel({
 					<Text style={styles.completeBtnText}>Complete</Text>
 				</TouchableOpacity>
 
-				<TouchableOpacity style={styles.navBtn} onPress={onNext}>
+				<TouchableOpacity
+					style={[styles.navBtn, lessonNumber >= totalLessons && styles.navBtnDisabled]}
+					disabled={lessonNumber >= totalLessons}
+					onPress={onNext}
+				>
 					<ChevronRight
 						size={18}
-						color={colors.text.primary}
+						color={lessonNumber >= totalLessons ? colors.text.disabled : colors.text.primary}
 						strokeWidth={2}
 					/>
 				</TouchableOpacity>

--- a/src/screens/learning/CourseDetailScreen.tsx
+++ b/src/screens/learning/CourseDetailScreen.tsx
@@ -40,8 +40,8 @@ type TabType = "overview" | "curriculum" | "about";
 export function CourseDetailScreen() {
 	const { t } = useLanguage();
 	const router = useRouter();
-	const params = useLocalSearchParams();
-	const courseId = params.id as string;
+	const { id } = useLocalSearchParams<{ id: string }>();
+	const courseId = id?.trim() || "";
 
 	const [activeTab, setActiveTab] = useState<TabType>("overview");
 	const [showEnrollModal, setShowEnrollModal] = useState(false);


### PR DESCRIPTION
## Summary
- **Validate route params** in the video player screen (`courseId`, `lessonId`): show a user-friendly error screen with back navigation instead of a perpetual loading spinner when params are missing/invalid or the lesson doesn't exist
- **Disable Next button on last lesson** in `LessonInfoPanel` — mirrors the existing Previous button behavior (disabled + dimmed on first lesson)
- **Fix unsafe `as string` cast** in `CourseDetailScreen` — properly extract and validate the `id` param using `useLocalSearchParams<{ id: string }>()`
- **Add i18n translations** for error messages in all 3 languages (English, Swahili, Amharic)

## Changed files
| File | Change |
|------|--------|
| `app/video/[courseId]/[lessonId].tsx` | Early return with error UI for invalid/missing params |
| `src/components/video/LessonInfoPanel.tsx` | Disable Next button when `lessonNumber >= totalLessons` |
| `src/screens/learning/CourseDetailScreen.tsx` | Type-safe param extraction instead of `as string` |
| `locales/{en,sw,am}/translation.json` | New keys: `goBack`, `lessonNotFound`, `lessonNotFoundMessage`, `invalidParams` |

## Test plan
- [ ] Navigate to `/video/invalid-course/invalid-lesson` — should show error screen with back button
- [ ] Navigate to a valid lesson — should work as before
- [ ] On last lesson of a course, verify the Next (chevron-right) button is disabled/dimmed
- [ ] On first lesson, verify Previous button is still disabled (no regression)
- [ ] Switch language to Swahili/Amharic and verify error messages display correctly
- [ ] Navigate to `/learning/courses/` with no ID — should show "Course Not Found" error

https://claude.ai/code/session_017LbBck1E6GuVAMWcHU8Y9t